### PR TITLE
feat(dashboard): shell components

### DIFF
--- a/ui/cursor-dashboard/components/dashboard/Layout.tsx
+++ b/ui/cursor-dashboard/components/dashboard/Layout.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { ReactNode } from "react";
+import { dashContainer, dashGrid } from "@/lib/ui";
+import SideNav from "./SideNav";
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className={dashContainer}>
+      <div className={dashGrid}>
+        {/* Nav renders FIRST so it appears above content on mobile */}
+        <SideNav />
+        <main className="flex flex-col gap-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/ui/cursor-dashboard/components/dashboard/SideNav.tsx
+++ b/ui/cursor-dashboard/components/dashboard/SideNav.tsx
@@ -1,0 +1,34 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { navList, navItem, navItemActive } from "@/lib/ui";
+
+const items = [
+  { href: "/dashboard",                  label: "Overview",           icon: "⏱️" },
+  { href: "/dashboard/settings",         label: "Settings",           icon: "⚙️" },
+  { href: "/dashboard/integrations",     label: "Integrations",       icon: "📦" },
+  { href: "/dashboard/background-agents",label: "Background Agents",  icon: "☁️" },
+  { href: "/dashboard/usage",            label: "Usage",              icon: "📊" },
+  { href: "/dashboard/billing",          label: "Billing & Invoices", icon: "🧾" },
+  { href: "/dashboard/docs",             label: "Docs",               icon: "📄" },
+  { href: "/dashboard/contact",          label: "Contact Us",         icon: "✉️" }
+];
+
+export default function SideNav() {
+  const pathname = usePathname();
+  return (
+    <aside className="lg:sticky lg:top-16 self-start">
+      <nav className={navList} aria-label="Dashboard sections">
+        {items.map(i => {
+          const active = pathname === i.href;
+          return (
+            <Link key={i.href} href={i.href} className={`${navItem} ${active ? navItemActive : ""}`}>
+              <span aria-hidden>{i.icon}</span>
+              <span>{i.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}


### PR DESCRIPTION
Adds Layout and SideNav only. No route or app/page.tsx edits.

- Add DashboardLayout component with responsive grid system
- Add SideNav component with mobile-first navigation  
- Uses Tailwind tokens: dashContainer, dashGrid, navList, navItem
- Nav-first DOM order for mobile responsiveness
- Sticky sidebar on desktop (lg:sticky lg:top-16)
- Build passes ✅ - no app/page.tsx changes

This is PR3 of 6 in the mobile-responsive dashboard implementation plan.