### PR TITLE
feat(dashboard): add all dashboard pages (Settings, Integrations, Background Agents, etc.)

### DIFF
--- a/ui/cursor-dashboard/app/dashboard/background-agents/page.tsx
+++ b/ui/cursor-dashboard/app/dashboard/background-agents/page.tsx
@@ -1,0 +1,12 @@
+import { sectionTitle, card } from "@/lib/ui";
+
+export default function Page() {
+  return (
+    <section className="flex flex-col gap-6">
+      <h1 className={sectionTitle}>Background Agents</h1>
+      <div className={card}>
+        <p className="text-sm text-zinc-400">Background Agents placeholder.</p>
+      </div>
+    </section>
+  );
+}

--- a/ui/cursor-dashboard/app/dashboard/billing/page.tsx
+++ b/ui/cursor-dashboard/app/dashboard/billing/page.tsx
@@ -1,0 +1,12 @@
+import { sectionTitle, card } from "@/lib/ui";
+
+export default function Page() {
+  return (
+    <section className="flex flex-col gap-6">
+      <h1 className={sectionTitle}>Billing & Invoices</h1>
+      <div className={card}>
+        <p className="text-sm text-zinc-400">Billing & Invoices placeholder.</p>
+      </div>
+    </section>
+  );
+}

--- a/ui/cursor-dashboard/app/dashboard/contact/page.tsx
+++ b/ui/cursor-dashboard/app/dashboard/contact/page.tsx
@@ -1,0 +1,12 @@
+import { sectionTitle, card } from "@/lib/ui";
+
+export default function Page() {
+  return (
+    <section className="flex flex-col gap-6">
+      <h1 className={sectionTitle}>Contact Us</h1>
+      <div className={card}>
+        <p className="text-sm text-zinc-400">Contact Us placeholder.</p>
+      </div>
+    </section>
+  );
+}

--- a/ui/cursor-dashboard/app/dashboard/docs/page.tsx
+++ b/ui/cursor-dashboard/app/dashboard/docs/page.tsx
@@ -1,0 +1,12 @@
+import { sectionTitle, card } from "@/lib/ui";
+
+export default function Page() {
+  return (
+    <section className="flex flex-col gap-6">
+      <h1 className={sectionTitle}>Docs</h1>
+      <div className={card}>
+        <p className="text-sm text-zinc-400">Docs placeholder.</p>
+      </div>
+    </section>
+  );
+}

--- a/ui/cursor-dashboard/app/dashboard/integrations/page.tsx
+++ b/ui/cursor-dashboard/app/dashboard/integrations/page.tsx
@@ -1,0 +1,12 @@
+import { sectionTitle, card } from "@/lib/ui";
+
+export default function Page() {
+  return (
+    <section className="flex flex-col gap-6">
+      <h1 className={sectionTitle}>Integrations</h1>
+      <div className={card}>
+        <p className="text-sm text-zinc-400">Integrations placeholder.</p>
+      </div>
+    </section>
+  );
+}

--- a/ui/cursor-dashboard/app/dashboard/layout.tsx
+++ b/ui/cursor-dashboard/app/dashboard/layout.tsx
@@ -1,0 +1,5 @@
+import DashboardLayout from "@/components/dashboard/Layout";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <DashboardLayout>{children}</DashboardLayout>;
+}

--- a/ui/cursor-dashboard/app/dashboard/page.tsx
+++ b/ui/cursor-dashboard/app/dashboard/page.tsx
@@ -1,0 +1,12 @@
+import { sectionTitle, card } from "@/lib/ui";
+
+export default function Page() {
+  return (
+    <section className="flex flex-col gap-6">
+      <h1 className={sectionTitle}>Overview</h1>
+      <div className={card}>
+        <p className="text-sm text-zinc-400">Overview placeholder.</p>
+      </div>
+    </section>
+  );
+}

--- a/ui/cursor-dashboard/app/dashboard/settings/page.tsx
+++ b/ui/cursor-dashboard/app/dashboard/settings/page.tsx
@@ -1,0 +1,12 @@
+import { sectionTitle, card } from "@/lib/ui";
+
+export default function Page() {
+  return (
+    <section className="flex flex-col gap-6">
+      <h1 className={sectionTitle}>Settings</h1>
+      <div className={card}>
+        <p className="text-sm text-zinc-400">Settings placeholder.</p>
+      </div>
+    </section>
+  );
+}

--- a/ui/cursor-dashboard/app/dashboard/usage/page.tsx
+++ b/ui/cursor-dashboard/app/dashboard/usage/page.tsx
@@ -1,0 +1,12 @@
+import { sectionTitle, card } from "@/lib/ui";
+
+export default function Page() {
+  return (
+    <section className="flex flex-col gap-6">
+      <h1 className={sectionTitle}>Usage</h1>
+      <div className={card}>
+        <p className="text-sm text-zinc-400">Usage placeholder.</p>
+      </div>
+    </section>
+  );
+}

--- a/ui/cursor-dashboard/components/dashboard/Layout.tsx
+++ b/ui/cursor-dashboard/components/dashboard/Layout.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { ReactNode } from "react";
+import { dashContainer, dashGrid } from "@/lib/ui";
+import SideNav from "./SideNav";
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className={dashContainer}>
+      <div className={dashGrid}>
+        {/* Nav renders FIRST so it appears above content on mobile */}
+        <SideNav />
+        <main className="flex flex-col gap-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/ui/cursor-dashboard/components/dashboard/SideNav.tsx
+++ b/ui/cursor-dashboard/components/dashboard/SideNav.tsx
@@ -1,0 +1,34 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { navList, navItem, navItemActive } from "@/lib/ui";
+
+const items = [
+  { href: "/dashboard",                  label: "Overview",           icon: "⏱️" },
+  { href: "/dashboard/settings",         label: "Settings",           icon: "⚙️" },
+  { href: "/dashboard/integrations",     label: "Integrations",       icon: "📦" },
+  { href: "/dashboard/background-agents",label: "Background Agents",  icon: "☁️" },
+  { href: "/dashboard/usage",            label: "Usage",              icon: "📊" },
+  { href: "/dashboard/billing",          label: "Billing & Invoices", icon: "🧾" },
+  { href: "/dashboard/docs",             label: "Docs",               icon: "📄" },
+  { href: "/dashboard/contact",          label: "Contact Us",         icon: "✉️" }
+];
+
+export default function SideNav() {
+  const pathname = usePathname();
+  return (
+    <aside className="lg:sticky lg:top-16 self-start">
+      <nav className={navList} aria-label="Dashboard sections">
+        {items.map(i => {
+          const active = pathname === i.href;
+          return (
+            <Link key={i.href} href={i.href} className={`${navItem} ${active ? navItemActive : ""}`}>
+              <span aria-hidden>{i.icon}</span>
+              <span>{i.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/ui/cursor-dashboard/lib/ui.ts
+++ b/ui/cursor-dashboard/lib/ui.ts
@@ -1,0 +1,7 @@
+export const dashContainer = "mx-auto max-w-[1120px] px-3 sm:px-4 lg:px-6";
+export const dashGrid      = "grid gap-6 lg:grid-cols-[18rem_1fr]";
+export const sectionTitle  = "text-lg font-medium tracking-tight";
+export const card          = "rounded-xl border border-white/10 bg-white/5 p-4 md:p-6";
+export const navList       = "flex flex-col gap-1";
+export const navItem       = "flex items-center gap-3 rounded-lg px-3 py-2 hover:bg-white/5";
+export const navItemActive = "bg-white/10";

--- a/ui/cursor-dashboard/tsconfig.json
+++ b/ui/cursor-dashboard/tsconfig.json
@@ -1,27 +1,29 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "Bundler",
     "jsx": "preserve",
-    "strict": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
     "baseUrl": ".",
     "paths": {
       "@/*": [
         "./*"
       ]
     },
+    "strict": true,
+    "noEmit": true,
+    "types": [
+      "node"
+    ],
     "lib": [
       "dom",
       "dom.iterable",
       "esnext"
     ],
     "allowJs": true,
-    "noEmit": true,
+    "skipLibCheck": true,
     "incremental": true,
+    "esModuleInterop": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "plugins": [
@@ -31,9 +33,7 @@
     ]
   },
   "include": [
-    "**/*.ts",
-    "**/*.tsx",
-    "next-env.d.ts",
+    "./**/*",
     ".next/types/**/*.ts"
   ],
   "exclude": [


### PR DESCRIPTION
Complete navigation structure with 8 dashboard routes. No changes to Agents.

- Add 7 additional dashboard pages: Settings, Integrations, Background Agents, Usage, Billing, Docs, Contact
- Each page uses sectionTitle + card pattern with placeholder content
- All pages use DashboardLayout + SideNav components
- Complete navigation structure with 8 total dashboard routes
- Build passes ✅ - all routes appear in build output
- No app/page.tsx changes - Agents functionality untouched

This is PR5 of 6 in the mobile-responsive dashboard implementation plan.